### PR TITLE
Set proper permission for file into /etc/sudoers.d

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,6 +146,9 @@ class sudo (
       purge   => $sudo::bool_source_dir_purge,
       replace => $sudo::manage_file_replace,
       audit   => $sudo::manage_audit,
+      mode    => $sudo::config_file_mode,
+      owner   => $sudo::config_file_owner,
+      group   => $sudo::config_file_group,
     }
   } else {
     # Basic /etc/sudoers header for old versions of sudo ( < 1.7.2 )


### PR DESCRIPTION
All file into /etc/sudoers.d directory should have 0440 permission for security purpose.

I hope this work is revelant and will help.

Thank's for your work.
Romain THERRAT
