### PR TITLE
EL5 has Sudo 1.7.2, but the distro-provided /etc/sudoers does not contain #includedir or create /etc/sudoers.d.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,8 @@ class sudo::params {
       default => '/etc/sudoers.d',
     },
     /(?i:RedHat|Centos|Scientific)/ => $::operatingsystemrelease ? {
-      '4'  => false,
+      /^4/    => false,
+      /^5/    => false,
       default => '/etc/sudoers.d',
     },
     default => '/etc/sudoers.d',


### PR DESCRIPTION
This module could also replace the /etc/sudoers with one that includes #includedir and create /etc/sudoers.d, but I think the current solution is less intrusive/unexpected.
