### PR TITLE
Allow content to be set via resouce name;

### DIFF
--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -44,7 +44,7 @@ define sudo::directive (
 
   # add a line break at the end, as missing that can make the file invalid
   $manage_content = $content ? {
-    ''        => undef,
+    ''        => $name,
     default   => inline_template('<%= [@content].flatten.join("\n") + "\n" %>'),
   }
 


### PR DESCRIPTION
Now i can write many directives easy way.
For example:

sudo::directive { "pgpool ip addr add ${master_ip}":
   content => 'postgres ALL=(ALL) NOPASSWD: /sbin/ip addr add ${master_ip}/24 dev eth0':
   content => 'postgres ALL=(ALL) NOPASSWD: /sbin/ip addr del ${master_ip}/24 dev eth0':
   content => 'postgres ALL=(ALL) NOPASSWD: /sbin/arping':
}
