### PR TITLE
Detect RedHat version for config dir

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,9 +32,9 @@ class sudo::params {
       default => '/etc/sudoers.d',
     },
     /(?i:RedHat|Centos|Scientific)/ => $::operatingsystemrelease ? {
-      /^4/    => false,
-      /^5/    => false,
-      default => '/etc/sudoers.d',
+      /^4/    	   => false,
+      /^5.[01234]/ => false,
+      default      => '/etc/sudoers.d',
     },
     /(?i:FreeBSD)/  => '/usr/local/etc/sudoers.d',
     default         => '/etc/sudoers.d',


### PR DESCRIPTION
Related to issue #16. This is the quick fix. I will try to  add the custom fact

*lib/facter/sudo_version.rb*

```puppet
Facter.add("sudo_version") do
  setcode do
    sudo_version = Facter::Util::Resolution.exec('sudo --version')
    if mysql_ver
      sudo_version.match(/\d+\.\d+\.\d+/)[0]
    else
      nill
    end
  end
end
```

I need to think the best approach between Linux using this fact and Linux/FreeBSD when this fact is not present.