### PR TITLE
allow redhat versions like 5.11 to use sudoers.d

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,9 +32,9 @@ class sudo::params {
       default => '/etc/sudoers.d',
     },
     /(?i:RedHat|Centos|Scientific)/ => $::operatingsystemrelease ? {
-      /^4/         => false,
-      /^5.[01234]/ => false,
-      default      => '/etc/sudoers.d',
+      /^4/          => false,
+      /^5.[01234]$/ => false,
+      default       => '/etc/sudoers.d',
     },
     /(?i:FreeBSD)/                  => '/usr/local/etc/sudoers.d',
     /(?i:XenServer)/                => false,


### PR DESCRIPTION
Hello

The current regex for deciding if the redhat version used was fine for versions 5.5 through 5.9 but broke at 5.10 which matched ^5.[01234]

I've changed the regex to ^5.[01234]$ in order that 5.10 and 5.11 can use sudoers.d